### PR TITLE
Re-organize AppJs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
-import React, { Component } from 'react'
-import { Route, Redirect } from 'react-router-dom'
-import MediaQuery from 'react-responsive'
-import Draft from './Draft/Draft'
-import RegisteredPlayers from './PreDraft/RegisteredPlayers'
-import DesktopRegister from './Registration/DesktopRegister/DesktopRegister'
-import MobileRegister from './Registration/MobileRegister/MobileRegister'
-import Confirmation from './Registration/Confirmation/Confirmation'
+import React, { Component } from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import MediaQuery from 'react-responsive';
+import Draft from './Draft/Draft';
+import RegisteredPlayers from './PreDraft/RegisteredPlayers';
+import DesktopRegister from './Registration/DesktopRegister/DesktopRegister';
+import MobileRegister from './Registration/MobileRegister/MobileRegister';
+import Confirmation from './Registration/Confirmation/Confirmation';
 
 export default function App() {
   return (
@@ -27,5 +27,5 @@ export default function App() {
         <Route path="/register" component={MobileRegister} />
       </MediaQuery>
     </div>
-  )
+  );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Route, Redirect } from 'react-router-dom'
 import MediaQuery from 'react-responsive'
 import Draft from './Draft/Draft'

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
-import { Route, Redirect } from 'react-router-dom';
-import MediaQuery from 'react-responsive';
-import Draft from './Draft/Draft';
-import RegisteredPlayers from './PreDraft/RegisteredPlayers';
-import DesktopRegister from './Registration/DesktopRegister/DesktopRegister';
-import MobileRegister from './Registration/MobileRegister/MobileRegister';
-import Confirmation from './Registration/Confirmation/Confirmation';
+import React, { Component } from 'react'
+import { Route, Redirect } from 'react-router-dom'
+import MediaQuery from 'react-responsive'
+import Draft from './Draft/Draft'
+import RegisteredPlayers from './PreDraft/RegisteredPlayers'
+import DesktopRegister from './Registration/DesktopRegister/DesktopRegister'
+import MobileRegister from './Registration/MobileRegister/MobileRegister'
+import Confirmation from './Registration/Confirmation/Confirmation'
 
 export default function App() {
   return (
@@ -27,5 +27,5 @@ export default function App() {
         <Route path="/register" component={MobileRegister} />
       </MediaQuery>
     </div>
-  );
+  )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,106 +1,31 @@
-import React, { Component } from 'react'
-import { BrowserRouter, Route, Redirect } from 'react-router-dom'
-import MediaQuery from 'react-responsive'
+import React, { Component } from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import MediaQuery from 'react-responsive';
+import Draft from './Draft/Draft';
+import RegisteredPlayers from './PreDraft/RegisteredPlayers';
+import DesktopRegister from './Registration/DesktopRegister/DesktopRegister';
+import MobileRegister from './Registration/MobileRegister/MobileRegister';
+import Confirmation from './Registration/Confirmation/Confirmation';
 
-// import Nav from './Routes/Interface/Nav'
-// import MobileNav from './Routes/Interface/MobileNav'
-import Draft from './Draft/Draft'
-import { Subscription } from './streamLib/stream'
-import RegisteredPlayers from './PreDraft/RegisteredPlayers'
-import DesktopRegister from './Registration/DesktopRegister/DesktopRegister'
-import MobileRegister from './Registration/MobileRegister/MobileRegister'
-import Confirmation from './Registration/Confirmation/Confirmation'
+export default function App() {
+  return (
+    <div>
+      <Route exact path="/" render={() => <Redirect to="/register" />} />
+      <Route path="/confirmed" component={Confirmation} />
+      <Route path="/players" component={RegisteredPlayers} />
+      <Route path="/draft" component={Draft} />
+      {/* WEB */}
+      <MediaQuery minDeviceWidth={1224}>
+        {/* <Nav /> */}
+        {/* <Route path='/draft' component={Draft} /> */}
+        <Route path="/register" component={DesktopRegister} />
+      </MediaQuery>
 
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
-import CssBaseline from '@material-ui/core/CssBaseline'
-
-import JssProvider from 'react-jss/lib/JssProvider'
-import { create } from 'jss'
-import { createGenerateClassName, jssPreset } from '@material-ui/core/styles'
-
-const theme = createMuiTheme({
-  palette: {
-    type: 'dark',
-    primary: { main: '#cdb87c' },
-    secondary: { main: '#c89b3c' }
-  },
-  overrides: {
-    MuiBottomNavigation: {
-      root: {
-        background: 'linear-gradient(#17252E, #0E171E)',
-        width: '100%',
-        borderTop: '1px solid #a47c41'
-      }
-    },
-    MuiBottomNavigationAction: {
-      root: {
-        '&$selected': { color: '#c89b3c' },
-        paddingTop: '10px'
-      }
-    },
-    MuiPaper: {
-      root: { backgroundColor: '#10193c' }
-    },
-    MuiSnackbarContent: {
-      root: {
-        backgroundColor: '#cdb87c',
-        padding: '0 24px'
-      }
-    }
-  }
-})
-
-const generateClassName = createGenerateClassName()
-const jss = create(jssPreset())
-
-export const UserContext = React.createContext({_key:''})
-
-class App extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {me: {_key: ''}}
-  }
-
-  componentDidMount() {
-    this.subscription = new Subscription('/me',
-    (info) => {
-      this.setState({
-        me: info
-      })
-    })
-  }
-
-  render() {
-    return (
-      <JssProvider jss={jss} generateClassName={generateClassName}>
-        <MuiThemeProvider theme={theme}>
-          <CssBaseline />
-          <UserContext.Provider value={this.state.me}>
-            <BrowserRouter>
-              <div>
-                <Route exact path='/' render={() => <Redirect to="/register" /> } />
-                <Route path='/confirmed' component={Confirmation} />
-                <Route path='/players' component={RegisteredPlayers} />
-                <Route path='/draft' component={Draft} />
-                {/* WEB */}
-                <MediaQuery minDeviceWidth={1224}>
-                  {/* <Nav /> */}
-                  {/* <Route path='/draft' component={Draft} /> */}
-                  <Route path='/register' component={DesktopRegister} />
-                </MediaQuery>
-
-                {/* MOBILE */}
-                <MediaQuery maxDeviceWidth={1224}>
-                  {/* <MobileNav /> */}
-                  <Route path='/register' component={MobileRegister} />
-                </MediaQuery>
-              </div>
-            </BrowserRouter>
-          </UserContext.Provider>
-        </MuiThemeProvider>
-      </JssProvider>
-    )
-  }
+      {/* MOBILE */}
+      <MediaQuery maxDeviceWidth={1224}>
+        {/* <MobileNav /> */}
+        <Route path="/register" component={MobileRegister} />
+      </MediaQuery>
+    </div>
+  );
 }
-
-export default App

--- a/src/Contexts/UserContext.js
+++ b/src/Contexts/UserContext.js
@@ -1,0 +1,31 @@
+import React, { Component, createContext } from 'react';
+import { Subscription } from '../streamLib/stream';
+
+const { Consumer, Provider } = createContext();
+
+export default class UserContext extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      me: {
+        _key: ''
+      }
+    };
+  }
+
+  componentDidMount() {
+    this.subscription = new Subscription('/me', info => {
+      this.setState({
+        me: info
+      });
+    });
+  }
+
+  render() {
+    const value = { ...this.state };
+    return <Provider value={value}>{this.props.children}</Provider>;
+  }
+}
+
+export const withUserContext = C => props => <Consumer>{value => <C {...value} {...props} />}</Consumer>;

--- a/src/Contexts/UserContext.js
+++ b/src/Contexts/UserContext.js
@@ -1,31 +1,31 @@
-import React, { Component, createContext } from 'react'
-import { Subscription } from '../streamLib/stream'
+import React, { Component, createContext } from 'react';
+import { Subscription } from '../streamLib/stream';
 
-const { Consumer, Provider } = createContext()
+const { Consumer, Provider } = createContext();
 
 export default class UserContext extends Component {
   constructor(props) {
-    super(props)
+    super(props);
 
     this.state = {
       me: {
         _key: ''
       }
-    }
+    };
   }
 
   componentDidMount() {
     this.subscription = new Subscription('/me', info => {
       this.setState({
         me: info
-      })
-    })
+      });
+    });
   }
 
   render() {
-    const value = { ...this.state }
-    return <Provider value={value}>{this.props.children}</Provider>
+    const value = { ...this.state };
+    return <Provider value={value}>{this.props.children}</Provider>;
   }
 }
 
-export const withUserContext = C => props => <Consumer>{value => <C {...value} {...props} />}</Consumer>
+export const withUserContext = C => props => <Consumer>{value => <C {...value} {...props} />}</Consumer>;

--- a/src/Contexts/UserContext.js
+++ b/src/Contexts/UserContext.js
@@ -1,31 +1,31 @@
-import React, { Component, createContext } from 'react';
-import { Subscription } from '../streamLib/stream';
+import React, { Component, createContext } from 'react'
+import { Subscription } from '../streamLib/stream'
 
-const { Consumer, Provider } = createContext();
+const { Consumer, Provider } = createContext()
 
 export default class UserContext extends Component {
   constructor(props) {
-    super(props);
+    super(props)
 
     this.state = {
       me: {
         _key: ''
       }
-    };
+    }
   }
 
   componentDidMount() {
     this.subscription = new Subscription('/me', info => {
       this.setState({
         me: info
-      });
-    });
+      })
+    })
   }
 
   render() {
-    const value = { ...this.state };
-    return <Provider value={value}>{this.props.children}</Provider>;
+    const value = { ...this.state }
+    return <Provider value={value}>{this.props.children}</Provider>
   }
 }
 
-export const withUserContext = C => props => <Consumer>{value => <C {...value} {...props} />}</Consumer>;
+export const withUserContext = C => props => <Consumer>{value => <C {...value} {...props} />}</Consumer>

--- a/src/Draft/Draft.js
+++ b/src/Draft/Draft.js
@@ -1,32 +1,32 @@
-import React, { Component } from 'react';
-import { Subscription } from '../streamLib/stream.js';
-import { withUserContext } from '../Contexts/UserContext';
-import MediaQuery from 'react-responsive';
-import MyTeam from './MyTeam/MyTeam';
-import PlayerList from './PlayerList/PlayerList';
-import TeamList from './TeamList/TeamList';
-import CurrentBid from './PlayerList/CurrentBid';
+import React, { Component } from 'react'
+import { Subscription } from '../streamLib/stream.js'
+import { withUserContext } from '../Contexts/UserContext'
+import MediaQuery from 'react-responsive'
+import MyTeam from './MyTeam/MyTeam'
+import PlayerList from './PlayerList/PlayerList'
+import TeamList from './TeamList/TeamList'
+import CurrentBid from './PlayerList/CurrentBid'
 
 class Draft extends Component {
   constructor(props) {
-    super(props);
-    this.state = { teams: [], players: [], myTeam: null };
+    super(props)
+    this.state = { teams: [], players: [], myTeam: null }
   }
 
   componentDidMount() {
     this.subscription = new Subscription('/draft', data => {
       this.setState({
         myTeam: data.teams.find(team => {
-          return team.roster.find(p => p._key === this.props.user._key);
+          return team.roster.find(p => p._key === this.props.user._key)
         }),
         teams: data.teams,
         players: data.players
-      });
-    });
+      })
+    })
   }
 
   componentWillUnmount() {
-    this.subscription && this.subscription.end();
+    this.subscription && this.subscription.end()
   }
 
   render() {
@@ -39,8 +39,8 @@ class Draft extends Component {
         <CurrentBid user={this.props.user} />
         <PlayerList user={this.props.user} players={this.state.players} />
       </div>
-    );
+    )
   }
 }
 
-export default withUserContext(Draft);
+export default withUserContext(Draft)

--- a/src/Draft/Draft.js
+++ b/src/Draft/Draft.js
@@ -1,32 +1,32 @@
-import React, { Component } from 'react'
-import { Subscription } from '../streamLib/stream.js'
-import { withUserContext } from '../Contexts/UserContext'
-import MediaQuery from 'react-responsive'
-import MyTeam from './MyTeam/MyTeam'
-import PlayerList from './PlayerList/PlayerList'
-import TeamList from './TeamList/TeamList'
-import CurrentBid from './PlayerList/CurrentBid'
+import React, { Component } from 'react';
+import { Subscription } from '../streamLib/stream.js';
+import { withUserContext } from '../Contexts/UserContext';
+import MediaQuery from 'react-responsive';
+import MyTeam from './MyTeam/MyTeam';
+import PlayerList from './PlayerList/PlayerList';
+import TeamList from './TeamList/TeamList';
+import CurrentBid from './PlayerList/CurrentBid';
 
 class Draft extends Component {
   constructor(props) {
-    super(props)
-    this.state = { teams: [], players: [], myTeam: null }
+    super(props);
+    this.state = { teams: [], players: [], myTeam: null };
   }
 
   componentDidMount() {
     this.subscription = new Subscription('/draft', data => {
       this.setState({
         myTeam: data.teams.find(team => {
-          return team.roster.find(p => p._key === this.props.user._key)
+          return team.roster.find(p => p._key === this.props.user._key);
         }),
         teams: data.teams,
         players: data.players
-      })
-    })
+      });
+    });
   }
 
   componentWillUnmount() {
-    this.subscription && this.subscription.end()
+    this.subscription && this.subscription.end();
   }
 
   render() {
@@ -39,8 +39,8 @@ class Draft extends Component {
         <CurrentBid user={this.props.user} />
         <PlayerList user={this.props.user} players={this.state.players} />
       </div>
-    )
+    );
   }
 }
 
-export default withUserContext(Draft)
+export default withUserContext(Draft);

--- a/src/Draft/Draft.js
+++ b/src/Draft/Draft.js
@@ -1,63 +1,46 @@
-import React, { Component } from 'react'
-import { Subscription } from '../streamLib/stream.js'
-import MediaQuery from 'react-responsive'
-
-import { UserContext } from '../App'
-import MyTeam from './MyTeam/MyTeam'
-import PlayerList from './PlayerList/PlayerList'
-import TeamList from './TeamList/TeamList'
-import CurrentBid from './PlayerList/CurrentBid'
+import React, { Component } from 'react';
+import { Subscription } from '../streamLib/stream.js';
+import { withUserContext } from '../Contexts/UserContext';
+import MediaQuery from 'react-responsive';
+import MyTeam from './MyTeam/MyTeam';
+import PlayerList from './PlayerList/PlayerList';
+import TeamList from './TeamList/TeamList';
+import CurrentBid from './PlayerList/CurrentBid';
 
 class Draft extends Component {
-
-  constructor (props) {
-    super(props)
-    this.state = {teams: [], players: [], myTeam: null}
+  constructor(props) {
+    super(props);
+    this.state = { teams: [], players: [], myTeam: null };
   }
 
   componentDidMount() {
-    this.subscription = new Subscription('/draft',
-    (data) => {
+    this.subscription = new Subscription('/draft', data => {
       this.setState({
-        myTeam: data.teams.find((team) => {
-          return team.roster.find((p)=> p._key === this.props.user._key)
+        myTeam: data.teams.find(team => {
+          return team.roster.find(p => p._key === this.props.user._key);
         }),
         teams: data.teams,
-        players: data.players})
-    })
+        players: data.players
+      });
+    });
   }
 
   componentWillUnmount() {
-    this.subscription && this.subscription.end()
+    this.subscription && this.subscription.end();
   }
 
-  render () {
+  render() {
     return (
-      <div style={{color: 'white'}}>
-          {this.state.myTeam ?
-            <MyTeam
-              user={this.props.user}
-              team={this.state.myTeam} /> : ''}
-          <MediaQuery minDeviceWidth={1224}>
-            <TeamList
-              user={this.props.user}
-              teams={this.state.teams} />
-          </MediaQuery>
-          <CurrentBid
-            user={this.props.user} />
-          <PlayerList
-            user={this.props.user}
-            players={this.state.players} />
+      <div style={{ color: 'white' }}>
+        {this.state.myTeam ? <MyTeam user={this.props.user} team={this.state.myTeam} /> : ''}
+        <MediaQuery minDeviceWidth={1224}>
+          <TeamList user={this.props.user} teams={this.state.teams} />
+        </MediaQuery>
+        <CurrentBid user={this.props.user} />
+        <PlayerList user={this.props.user} players={this.state.players} />
       </div>
-    )
+    );
   }
 }
 
-
-export default props => (
-  <UserContext.Consumer>
-    {user => (
-      <Draft {...props} user={user} />
-    )}
-  </UserContext.Consumer>
-)
+export default withUserContext(Draft);

--- a/src/PreDraft/RegisteredPlayers.js
+++ b/src/PreDraft/RegisteredPlayers.js
@@ -28,7 +28,7 @@ class RegisteredPlayers extends Component {
   render() {
     const { me } = this.props
     const playersList = this.state.data.map(user => {
-      if (user === me) {
+      if (user === me._key) {
         return <EditTableContent key={user} user={user} me={me} />
       } else {
         return <PlayerTableContent key={user} user={user} me={me} />

--- a/src/PreDraft/RegisteredPlayers.js
+++ b/src/PreDraft/RegisteredPlayers.js
@@ -1,38 +1,45 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
 
-import { Subscription } from '../streamLib/stream'
-import { UserContext } from '../App'
-import EditTableContent from './EditTableContent'
-import PlayerTableContent from './PlayerTableContent'
+import { Subscription } from '../streamLib/stream';
+import { withUserContext } from '../Contexts/UserContext';
+import EditTableContent from './EditTableContent';
+import PlayerTableContent from './PlayerTableContent';
 
-import './PlayerList.css'
+import './PlayerList.css';
 
 class RegisteredPlayers extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {data: []}
+  constructor(props) {
+    super(props);
+    this.state = { data: [] };
   }
 
   componentDidMount() {
-    this.subscription = new Subscription('/users',
-    (info) => {
+    this.subscription = new Subscription('/users', info => {
       this.setState({
         data: info
-      })
-    })
+      });
+    });
   }
 
   componentWillUnmount() {
-    this.subscription && this.subscription.end()
+    this.subscription && this.subscription.end();
   }
 
-  render () {
+  render() {
+    const { me } = this.props;
+    const playersList = this.state.data.map(user => {
+      if (user === me) {
+        return <EditTableContent key={user} user={user} me={me} />;
+      } else {
+        return <PlayerTableContent key={user} user={user} me={me} />;
+      }
+    });
     return (
-      <div className='playerListDisplay'>
-        <table className='tableContainer'>
+      <div className="playerListDisplay">
+        <table className="tableContainer">
           <thead>
             <tr>
-              <th></th>
+              <th />
               <th>Player Name</th>
               <th>Summoner Name</th>
               <th>Roles</th>
@@ -40,23 +47,11 @@ class RegisteredPlayers extends Component {
               <th>Captain</th>
             </tr>
           </thead>
-          <tbody>
-            {this.state.data.map((user) => {
-              return (
-                <UserContext.Consumer key={user}>
-                  {(me) => {
-                    return user === me._key
-                    ? <EditTableContent key={user} user={user} me={me} />
-                    : <PlayerTableContent key={user} user={user} me={me} />
-                  }}
-                </UserContext.Consumer>
-              )
-            })}
-          </tbody>
+          <tbody>{playersList}</tbody>
         </table>
       </div>
-    )
+    );
   }
 }
 
-export default RegisteredPlayers
+export default withUserContext(RegisteredPlayers);

--- a/src/PreDraft/RegisteredPlayers.js
+++ b/src/PreDraft/RegisteredPlayers.js
@@ -1,39 +1,39 @@
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 
-import { Subscription } from '../streamLib/stream';
-import { withUserContext } from '../Contexts/UserContext';
-import EditTableContent from './EditTableContent';
-import PlayerTableContent from './PlayerTableContent';
+import { Subscription } from '../streamLib/stream'
+import { withUserContext } from '../Contexts/UserContext'
+import EditTableContent from './EditTableContent'
+import PlayerTableContent from './PlayerTableContent'
 
-import './PlayerList.css';
+import './PlayerList.css'
 
 class RegisteredPlayers extends Component {
   constructor(props) {
-    super(props);
-    this.state = { data: [] };
+    super(props)
+    this.state = { data: [] }
   }
 
   componentDidMount() {
     this.subscription = new Subscription('/users', info => {
       this.setState({
         data: info
-      });
-    });
+      })
+    })
   }
 
   componentWillUnmount() {
-    this.subscription && this.subscription.end();
+    this.subscription && this.subscription.end()
   }
 
   render() {
-    const { me } = this.props;
+    const { me } = this.props
     const playersList = this.state.data.map(user => {
       if (user === me) {
-        return <EditTableContent key={user} user={user} me={me} />;
+        return <EditTableContent key={user} user={user} me={me} />
       } else {
-        return <PlayerTableContent key={user} user={user} me={me} />;
+        return <PlayerTableContent key={user} user={user} me={me} />
       }
-    });
+    })
     return (
       <div className="playerListDisplay">
         <table className="tableContainer">
@@ -50,8 +50,8 @@ class RegisteredPlayers extends Component {
           <tbody>{playersList}</tbody>
         </table>
       </div>
-    );
+    )
   }
 }
 
-export default withUserContext(RegisteredPlayers);
+export default withUserContext(RegisteredPlayers)

--- a/src/assets/muiTheme.js
+++ b/src/assets/muiTheme.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createMuiTheme } from '@material-ui/core/styles'
 
 const theme = createMuiTheme({
   palette: {
@@ -30,6 +30,6 @@ const theme = createMuiTheme({
       }
     }
   }
-});
+})
 
-export default theme;
+export default theme

--- a/src/assets/muiTheme.js
+++ b/src/assets/muiTheme.js
@@ -1,0 +1,35 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+const theme = createMuiTheme({
+  palette: {
+    type: 'dark',
+    primary: { main: '#cdb87c' },
+    secondary: { main: '#c89b3c' }
+  },
+  overrides: {
+    MuiBottomNavigation: {
+      root: {
+        background: 'linear-gradient(#17252E, #0E171E)',
+        width: '100%',
+        borderTop: '1px solid #a47c41'
+      }
+    },
+    MuiBottomNavigationAction: {
+      root: {
+        '&$selected': { color: '#c89b3c' },
+        paddingTop: '10px'
+      }
+    },
+    MuiPaper: {
+      root: { backgroundColor: '#10193c' }
+    },
+    MuiSnackbarContent: {
+      root: {
+        backgroundColor: '#cdb87c',
+        padding: '0 24px'
+      }
+    }
+  }
+});
+
+export default theme;

--- a/src/assets/muiTheme.js
+++ b/src/assets/muiTheme.js
@@ -1,4 +1,4 @@
-import { createMuiTheme } from '@material-ui/core/styles'
+import { createMuiTheme } from '@material-ui/core/styles';
 
 const theme = createMuiTheme({
   palette: {
@@ -30,6 +30,6 @@ const theme = createMuiTheme({
       }
     }
   }
-})
+});
 
-export default theme
+export default theme;

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import 'normalize.css';
-import './index.css';
-import App from './App';
-import { BrowserRouter } from 'react-router-dom';
-import { unregister } from './registerServiceWorker';
-import { MuiThemeProvider } from '@material-ui/core/styles';
-import CssBaseline from '@material-ui/core/CssBaseline';
-import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
-import theme from './assets/muiTheme';
-import JssProvider from 'react-jss/lib/JssProvider';
-import { create } from 'jss';
-import UserProvider from './Contexts/UserContext';
-const jss = create(jssPreset());
-const generateClassName = createGenerateClassName();
+import React from 'react'
+import ReactDOM from 'react-dom'
+import 'normalize.css'
+import './index.css'
+import App from './App'
+import { BrowserRouter } from 'react-router-dom'
+import { unregister } from './registerServiceWorker'
+import { MuiThemeProvider } from '@material-ui/core/styles'
+import CssBaseline from '@material-ui/core/CssBaseline'
+import { createGenerateClassName, jssPreset } from '@material-ui/core/styles'
+import theme from './assets/muiTheme'
+import JssProvider from 'react-jss/lib/JssProvider'
+import { create } from 'jss'
+import UserProvider from './Contexts/UserContext'
+const jss = create(jssPreset())
+const generateClassName = createGenerateClassName()
 
 ReactDOM.render(
   <UserProvider>
@@ -28,5 +28,5 @@ ReactDOM.render(
     </BrowserRouter>
   </UserProvider>,
   document.getElementById('root')
-);
-unregister();
+)
+unregister()

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,30 @@ import ReactDOM from 'react-dom';
 import 'normalize.css';
 import './index.css';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 import { unregister } from './registerServiceWorker';
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
+import theme from './assets/muiTheme';
+import JssProvider from 'react-jss/lib/JssProvider';
+import { create } from 'jss';
+import UserProvider from './Contexts/UserContext';
+const jss = create(jssPreset());
+const generateClassName = createGenerateClassName();
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+  <UserProvider>
+    <BrowserRouter>
+      <JssProvider jss={jss} generateClassName={generateClassName}>
+        <MuiThemeProvider theme={theme}>
+          <CssBaseline>
+            <App />
+          </CssBaseline>
+        </MuiThemeProvider>
+      </JssProvider>
+    </BrowserRouter>
+  </UserProvider>,
+  document.getElementById('root')
+);
 unregister();

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,19 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import 'normalize.css'
-import './index.css'
-import App from './App'
-import { BrowserRouter } from 'react-router-dom'
-import { unregister } from './registerServiceWorker'
-import { MuiThemeProvider } from '@material-ui/core/styles'
-import CssBaseline from '@material-ui/core/CssBaseline'
-import { createGenerateClassName, jssPreset } from '@material-ui/core/styles'
-import theme from './assets/muiTheme'
-import JssProvider from 'react-jss/lib/JssProvider'
-import { create } from 'jss'
-import UserProvider from './Contexts/UserContext'
-const jss = create(jssPreset())
-const generateClassName = createGenerateClassName()
+import React from 'react';
+import ReactDOM from 'react-dom';
+import 'normalize.css';
+import './index.css';
+import App from './App';
+import { BrowserRouter } from 'react-router-dom';
+import { unregister } from './registerServiceWorker';
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
+import theme from './assets/muiTheme';
+import JssProvider from 'react-jss/lib/JssProvider';
+import { create } from 'jss';
+import UserProvider from './Contexts/UserContext';
+const jss = create(jssPreset());
+const generateClassName = createGenerateClassName();
 
 ReactDOM.render(
   <UserProvider>
@@ -28,5 +28,5 @@ ReactDOM.render(
     </BrowserRouter>
   </UserProvider>,
   document.getElementById('root')
-)
-unregister()
+);
+unregister();


### PR DESCRIPTION
App.js was starting to get a bit out of hand and unreadable. Many of the components being utilized there would be better suited on index.js and wrapped around the app as opposed to within the app. 

The reason for this decision is that that App.js will be used and modified more often than index.js thus only the necessary code should go there. With these changes, App.js could be stateless, reducing the number of states needed across the app. 

Also, modified are the usages of context across the code. A higher order function was created in the new User Context component that will make it easier to utilize the shared state. 